### PR TITLE
feat: add language switch and placeholders

### DIFF
--- a/index.html
+++ b/index.html
@@ -9,48 +9,45 @@
 <body>
   <div class="container">
     <section class="hero">
-      <header class="hero-header">
-        <div class="logo">PetSpot</div>
-        <nav>
-          <ul class="nav">
-            <li><a href="#home">Главная</a></li>
-            <li><a href="#features">Функции</a></li>
-            <li><a href="#download">Скачать</a></li>
-            <li><a href="#contacts">Контакты</a></li>
-          </ul>
-        </nav>
-      </header>
+      <div class="lang-switch" aria-label="Language">
+        <button data-lang="ge">GE</button>
+        <span class="sep">|</span>
+        <button data-lang="ru" class="active">RU</button>
+        <span class="sep">|</span>
+        <button data-lang="en">EN</button>
+      </div>
 
       <div class="hero-body">
         <div class="hero-left">
-          <h1>PetSpot — онлайн-паспорт питомца и услуги рядом</h1>
-          <p>Храните прививки и документы, находите грумеров, ветеринаров и передержку по вашему городу</p>
+          <h1 data-i18n="hero_title">PetSpot — онлайн-паспорт питомца и услуги рядом</h1>
+          <p data-i18n="hero_subtitle">Храните прививки и документы, находите грумеров, ветеринаров и передержку по вашему городу</p>
 
           <div class="store-row">
-            <a class="store-badge appstore" href="#" aria-label="Загрузите в App Store">Загрузите в App Store</a>
-            <a class="store-badge playmarket" href="#" aria-label="Доступно в Google Play">Доступно в Google Play</a>
+            <a class="store-badge appstore" href="#" aria-label="App Store badge"><!-- TODO: appstore-badge.png --></a>
+            <a class="store-badge playmarket" href="#" aria-label="Google Play badge"><!-- TODO: googleplay-badge.png --></a>
           </div>
 
           <div class="feature-cards">
-            <div class="card"><div class="icon">P</div><div class="title">Онлайн-паспорт</div></div>
-            <div class="card"><div class="icon">•</div><div class="title">Услуги рядом</div></div>
+            <div class="card"><div class="icon">P</div><div class="title" data-i18n="card_passport">Онлайн-паспорт</div></div>
+            <div class="card"><div class="icon">•</div><div class="title" data-i18n="card_services">Услуги рядом</div></div>
           </div>
         </div>
 
         <aside class="hero-right">
           <div class="phone">
-            <div class="phone-item"><div class="dot">S</div><div class="label">Паспорт</div></div>
-            <div class="phone-item"><div class="dot">•</div><div class="label">Услуги рядом</div></div>
-            <div class="phone-item"><div class="dot">+</div><div class="label">Ветклиники</div></div>
+            <div class="phone-item"><div class="dot">S</div><div class="label" data-i18n="phone_passport">Паспорт</div></div>
+            <div class="phone-item"><div class="dot">•</div><div class="label" data-i18n="phone_services">Услуги рядом</div></div>
+            <div class="phone-item"><div class="dot">+</div><div class="label" data-i18n="phone_vet">Ветклиники</div></div>
           </div>
 
           <div class="hero-meta">
-            <div class="meta-title">Booking – Безопасность</div>
-            <a class="meta-link" href="#">Политика конфиденциальности</a>
+            <div class="meta-title" data-i18n="meta_title">Booking – Безопасность</div>
+            <a class="meta-link" href="#" data-i18n="meta_link">Политика конфиденциальности</a>
           </div>
         </aside>
       </div>
     </section>
   </div>
 </body>
+<script src="script.js"></script>
 </html>

--- a/script.js
+++ b/script.js
@@ -1,8 +1,59 @@
 const langButtons = document.querySelectorAll('.lang-switch button');
+const texts = document.querySelectorAll('[data-i18n]');
+
+const translations = {
+  ru: {
+    hero_title: 'PetSpot — онлайн-паспорт питомца и услуги рядом',
+    hero_subtitle: 'Храните прививки и документы, находите грумеров, ветеринаров и передержку по вашему городу',
+    card_passport: 'Онлайн-паспорт',
+    card_services: 'Услуги рядом',
+    phone_passport: 'Паспорт',
+    phone_services: 'Услуги рядом',
+    phone_vet: 'Ветклиники',
+    meta_title: 'Booking – Безопасность',
+    meta_link: 'Политика конфиденциальности'
+  },
+  ge: {
+    hero_title: 'PetSpot – Online-Haustierpass und Dienste in der Nähe',
+    hero_subtitle: 'Speichern Sie Impfungen und Dokumente, finden Sie Groomer, Tierärzte und Betreuung in Ihrer Stadt',
+    card_passport: 'Online-Pass',
+    card_services: 'Dienste in der Nähe',
+    phone_passport: 'Pass',
+    phone_services: 'Dienste in der Nähe',
+    phone_vet: 'Tierkliniken',
+    meta_title: 'Booking – Sicherheit',
+    meta_link: 'Datenschutzerklärung'
+  },
+  en: {
+    hero_title: 'PetSpot — online pet passport and services nearby',
+    hero_subtitle: 'Store vaccinations and documents, find groomers, vets, and boarding in your city',
+    card_passport: 'Online Passport',
+    card_services: 'Services Nearby',
+    phone_passport: 'Passport',
+    phone_services: 'Services Nearby',
+    phone_vet: 'Vet Clinics',
+    meta_title: 'Booking – Safety',
+    meta_link: 'Privacy Policy'
+  }
+};
+
+function setLanguage(lang) {
+  texts.forEach(el => {
+    const key = el.dataset.i18n;
+    if (translations[lang] && translations[lang][key]) {
+      el.textContent = translations[lang][key];
+    }
+  });
+  document.documentElement.setAttribute('lang', lang);
+}
 
 langButtons.forEach(btn => {
   btn.addEventListener('click', () => {
     langButtons.forEach(b => b.classList.remove('active'));
     btn.classList.add('active');
+    setLanguage(btn.dataset.lang);
   });
 });
+
+setLanguage('ru');
+

--- a/styles.css
+++ b/styles.css
@@ -37,43 +37,46 @@ a:focus {
 }
 
 .hero {
-  margin-top: 24px;
-  background: var(--light-surface);
-  border-radius: 28px;
-  padding: 48px;
-  box-shadow: 0 16px 40px rgba(0,0,0,.07);
-}
+    margin-top: 24px;
+    background: var(--light-surface);
+    border-radius: 28px;
+    padding: 48px;
+    box-shadow: 0 16px 40px rgba(0,0,0,.07);
+    position: relative;
+  }
 
-.hero-header {
-  display: flex;
-  justify-content: space-between;
-  align-items: center;
-}
+  .hero-body {
+    display: flex;
+    gap: 40px;
+    align-items: center;
+    margin-top: 40px;
+  }
 
-.logo {
-  font-size: 1.5rem;
-  font-weight: 700;
-}
+  .lang-switch {
+    position: absolute;
+    top: 16px;
+    right: 16px;
+    display: flex;
+    align-items: center;
+    font-size: 14px;
+    gap: 4px;
+  }
 
-.nav {
-  list-style: none;
-  display: flex;
-  gap: 24px;
-  margin: 0;
-  padding: 0;
-}
+  .lang-switch button {
+    background: none;
+    border: none;
+    color: var(--black);
+    cursor: pointer;
+    padding: 0;
+  }
 
-.nav a {
-  color: var(--black);
-  font-size: 16px;
-}
+  .lang-switch button.active {
+    color: var(--accent-orange);
+  }
 
-.hero-body {
-  display: flex;
-  gap: 40px;
-  align-items: center;
-  margin-top: 40px;
-}
+  .lang-switch .sep {
+    color: var(--light-gray);
+  }
 
 .hero-left {
   flex: 1 1 60%;


### PR DESCRIPTION
## Summary
- remove old header and introduce top-right language switch
- add empty slots for app store badges with TODO notes
- implement RU/GE/EN translations and dynamic switcher

## Testing
- `npm test` *(fails: ENOENT package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68c00d2ccf0483319097fb5c573a9481