### PR TITLE
Show no results message on services filter

### DIFF
--- a/script.js
+++ b/script.js
@@ -271,6 +271,12 @@ async function renderServicesPage(selectedCityId = "all", selectedTypes = []) {
     const cities = await fetchCities();
     const services = await fetchUsersServices();
 
+    const noResultsMessages = {
+        ru: "Ничего не найдено ☹️",
+        ge: "ვერაფერი მოიძებნა ☹️",
+        en: "Nothing found ☹️",
+    };
+
     // фильтр по городу
     let filteredServices = (selectedCityId === "all")
         ? services
@@ -313,8 +319,8 @@ async function renderServicesPage(selectedCityId = "all", selectedTypes = []) {
       </div>
 
       <div class="services-main">
-        <div class="cards-grid">
-          ${filteredServices.map((s,idx) => {
+        <div class="cards-grid${filteredServices.length ? "" : " empty"}">
+          ${filteredServices.length ? filteredServices.map((s,idx) => {
         const category = categories.find(c => String(c.id) === String(s.type));
         const serviceName = category
             ? (currentLang === "ru" ? category.ruName : currentLang === "ge" ? category.geName : category.enName)
@@ -324,7 +330,7 @@ async function renderServicesPage(selectedCityId = "all", selectedTypes = []) {
                       <h3>${s.name || ""}</h3>
                       <p>${serviceName}</p>
                     </div>`;
-    }).join("")}
+    }).join("") : `<div class="no-results">${noResultsMessages[currentLang] || noResultsMessages.ru}</div>`}
         </div>
       </div>
     </div>`;

--- a/styles.css
+++ b/styles.css
@@ -475,6 +475,13 @@ p {
     gap: 20px;
 }
 
+.cards-grid.empty {
+    display: flex;
+    justify-content: center;
+    align-items: center;
+    min-height: 200px;
+}
+
 .service-card {
     background: #ffffff;
     border-radius: 12px;
@@ -502,6 +509,13 @@ p {
     font-size: 14px;
     color: #666;
     margin: 0; /* убираем глобальный огромный отступ */
+}
+
+.no-results {
+    text-align: center;
+    font-size: 18px;
+    color: #666;
+    width: 100%;
 }
 
 .cards-grid.one-column {


### PR DESCRIPTION
## Summary
- display a localized "nothing found" notice with a sad emoji when service filters return no matches
- center and style the empty-state message in the services grid

## Testing
- not run (not provided)


------
https://chatgpt.com/codex/tasks/task_e_68d19c2620e48331980d1267262721b6