### PR TITLE
Add services booking warning banner

### DIFF
--- a/script.js
+++ b/script.js
@@ -44,6 +44,7 @@ const translations = {
         services_filters_services: "Услуги",
         services_filters_apply: "Применить",
         services_filters_all_cities: "Все города",
+        services_warning: "В данный момент записаться на услугу можно только через приложение",
     },
     ge: {
         hero_title: 'PetSpot — შეუცვლელი დამხმარე თქვენთვის და თქვენი ცხოველისთვის',
@@ -74,6 +75,7 @@ const translations = {
         services_filters_services: "სერვისები",
         services_filters_apply: "გამოყენება",
         services_filters_all_cities: "ყველა ქალაქი",
+        services_warning: "ამჟამად სერვისზე ჩაწერა მხოლოდ აპლიკაციიდან შეიძლება",
     },
     en: {
         hero_title: 'PetSpot — an essential helper for you and your pet',
@@ -103,6 +105,7 @@ const translations = {
         services_filters_services: "Services",
         services_filters_apply: "Apply",
         services_filters_all_cities: "All cities",
+        services_warning: "At the moment, you can book a service only through the app",
     }
 };
 
@@ -304,6 +307,10 @@ async function renderServicesPage(selectedCityId = "all", selectedTypes = []) {
     }
 
     pageContent.innerHTML = `
+    <div class="services-warning">
+      <span class="services-warning__emoji">⚠️</span>
+      <span data-i18n="services_warning">${t.services_warning}</span>
+    </div>
     <div class="services-layout">
       <div class="filter-card">
         <h3>${t.services_filters_title}</h3>

--- a/styles.css
+++ b/styles.css
@@ -452,6 +452,23 @@ p {
 }
 
 /* Общий контейнер для фильтра и контента */
+.services-warning {
+    display: flex;
+    align-items: center;
+    gap: 12px;
+    margin-bottom: 24px;
+    padding: 12px 16px;
+    border-radius: 12px;
+    background: rgba(231, 76, 60, 0.12);
+    color: #a5312a;
+    font-weight: 600;
+}
+
+.services-warning__emoji {
+    font-size: 20px;
+    line-height: 1;
+}
+
 .services-layout {
     display: flex;
     gap: 32px; /* расстояние между фильтром и заголовком */


### PR DESCRIPTION
## Summary
- add localized warning banner to the services page reminding users that booking is only available in the app
- style the new banner with a soft red background and emoji to highlight the limitation

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68d1a4caf25c83319b520351510fc07c