### PR TITLE
Fix services banner layout and clinic switcher width

### DIFF
--- a/script.js
+++ b/script.js
@@ -246,6 +246,8 @@ function showPage(page) {
             await renderClinicsPage();
         }
 
+        pageContent.classList.toggle("page-stack", page !== "home");
+
         applyTranslations();
 
         if (page === "home") {

--- a/styles.css
+++ b/styles.css
@@ -133,6 +133,13 @@ a:focus {
     margin-top: 40px;
 }
 
+.hero-body.page-stack {
+    display: flex;
+    flex-direction: column;
+    align-items: stretch;
+    gap: 32px;
+}
+
 .hero-body.services-mode { display: block; }
 
 .hero-left { flex: 1 1 60%; }
@@ -659,6 +666,10 @@ p {
     border-radius: 8px;
     overflow: hidden;
     margin: 12px 0 20px;
+}
+
+.services-main > .view-switch {
+    align-self: flex-start;
 }
 
 .view-switch button {


### PR DESCRIPTION
## Summary
- ensure the services page warning banner uses the full topbar width by switching the hero body to a stacked layout on internal pages
- prevent the clinics view switcher border from stretching by aligning the control to its button width only

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68d1a64ffd0c83318de6c90c8b337a37