### PR TITLE
Fix clinic filter card width consistency

### DIFF
--- a/styles.css
+++ b/styles.css
@@ -374,6 +374,7 @@ p {
     flex-direction: column;
     gap: 16px;
     width: 240px;                    /* фиксированная ширина */
+    flex: 0 0 240px;                 /* не даём сжиматься во флексе */
 }
 
 .filter-card h3 {


### PR DESCRIPTION
## Summary
- prevent the clinic filters card from shrinking when switching to the map view

## Testing
- no automated tests were run (not available)

------
https://chatgpt.com/codex/tasks/task_e_68d1ae4627348331bb0879c7a7217489