### PR TITLE
Adjust clinic login layout and improve clinic auth

### DIFF
--- a/clinic/cabinet/cabinet.js
+++ b/clinic/cabinet/cabinet.js
@@ -1,0 +1,203 @@
+import { db } from "../../firebase-init.js";
+import {
+    collection,
+    getDocs,
+    limit,
+    query,
+    where
+} from "https://www.gstatic.com/firebasejs/10.12.2/firebase-firestore.js";
+
+const SESSION_KEY = 'petspotClinicSession';
+
+const nameEl = document.getElementById('clinic-name');
+const infoEl = document.getElementById('clinic-info');
+const extraEl = document.getElementById('cabinet-extra');
+const layoutEl = document.getElementById('cabinet-layout');
+const emptyEl = document.getElementById('cabinet-empty');
+const subtitleEl = document.getElementById('cabinet-subtitle');
+const logoutButtons = [
+    document.getElementById('clinic-logout'),
+    document.getElementById('cabinet-logout-fallback')
+];
+
+function readSession() {
+    try {
+        const raw = localStorage.getItem(SESSION_KEY);
+        if (!raw) return null;
+        return JSON.parse(raw);
+    } catch (error) {
+        console.error('Unable to parse clinic session', error);
+        return null;
+    }
+}
+
+function clearSession() {
+    localStorage.removeItem(SESSION_KEY);
+}
+
+function redirectToLogin() {
+    window.location.replace('../login/');
+}
+
+logoutButtons.forEach((btn) => {
+    if (!btn) return;
+    btn.addEventListener('click', () => {
+        clearSession();
+        redirectToLogin();
+    });
+});
+
+function isUrl(value) {
+    if (typeof value !== 'string') return false;
+    return value.startsWith('http://') || value.startsWith('https://');
+}
+
+function appendInfo(label, value) {
+    if (!value && value !== 0) return;
+
+    const row = document.createElement('div');
+    row.className = 'cabinet-info-row';
+
+    const labelEl = document.createElement('div');
+    labelEl.className = 'cabinet-info-label';
+    labelEl.textContent = label;
+
+    const valueEl = document.createElement('div');
+    valueEl.className = 'cabinet-info-value';
+
+    if (isUrl(value)) {
+        const link = document.createElement('a');
+        link.href = value;
+        link.target = '_blank';
+        link.rel = 'noopener noreferrer';
+        link.textContent = value;
+        valueEl.appendChild(link);
+    } else {
+        valueEl.textContent = value;
+    }
+
+    row.append(labelEl, valueEl);
+    infoEl?.appendChild(row);
+}
+
+function renderClinicInfo(session, clinicData) {
+    if (!infoEl) return;
+    infoEl.innerHTML = '';
+
+    appendInfo('Логин', session.username);
+
+    const name = clinicData?.name || session.name || 'Клиника';
+    if (nameEl) {
+        nameEl.textContent = name;
+    }
+
+    const fields = [
+        ['owner', 'Контактное лицо'],
+        ['phone', 'Телефон'],
+        ['email', 'Email'],
+        ['address', 'Адрес'],
+        ['geoAddress', 'Адрес на карте'],
+        ['facebook', 'Facebook'],
+        ['instagram', 'Instagram'],
+        ['tiktok', 'TikTok'],
+        ['website', 'Сайт'],
+        ['googleMaps', 'Google Maps'],
+        ['whatsapp', 'WhatsApp'],
+        ['telegram', 'Telegram'],
+        ['viber', 'Viber']
+    ];
+
+    fields.forEach(([key, label]) => {
+        if (clinicData && key in clinicData) {
+            appendInfo(label, clinicData[key]);
+        }
+    });
+
+    if (clinicData && ('lat' in clinicData || 'lon' in clinicData)) {
+        const coords = [clinicData.lat, clinicData.lon]
+            .filter((value) => value !== undefined && value !== null)
+            .join(', ');
+        if (coords) {
+            appendInfo('Координаты', coords);
+        }
+    }
+
+    if (clinicData && extraEl) {
+        extraEl.innerHTML = '';
+        if (clinicData.description) {
+            const desc = document.createElement('p');
+            desc.textContent = clinicData.description;
+            extraEl.appendChild(desc);
+        }
+
+        if (clinicData.services && Array.isArray(clinicData.services) && clinicData.services.length) {
+            const listTitle = document.createElement('h2');
+            listTitle.textContent = 'Услуги клиники';
+            const list = document.createElement('ul');
+            clinicData.services.forEach((service) => {
+                const item = document.createElement('li');
+                item.textContent = service;
+                list.appendChild(item);
+            });
+            extraEl.append(listTitle, list);
+        }
+    }
+}
+
+async function fetchClinic(clinicId) {
+    if (!clinicId) return null;
+    const clinicsRef = collection(db, 'vet_clinics');
+    const q = query(clinicsRef, where('id', '==', clinicId), limit(1));
+    const snap = await getDocs(q);
+    if (snap.empty) {
+        return null;
+    }
+    const doc = snap.docs[0];
+    return { id: doc.id, ...doc.data() };
+}
+
+async function initCabinet() {
+    const session = readSession();
+    if (!session) {
+        redirectToLogin();
+        return;
+    }
+
+    if (layoutEl) {
+        layoutEl.hidden = true;
+    }
+    if (emptyEl) {
+        emptyEl.hidden = true;
+    }
+    if (subtitleEl) {
+        subtitleEl.textContent = 'Загрузка данных клиники...';
+    }
+
+    try {
+        const clinicData = await fetchClinic(session.clinicId);
+        if (!clinicData) {
+            throw new Error('Clinic data not found');
+        }
+
+        renderClinicInfo(session, clinicData);
+        if (subtitleEl) {
+            subtitleEl.textContent = 'Управляйте профилем и услугами вашей клиники. Новые инструменты скоро появятся.';
+        }
+        if (layoutEl) {
+            layoutEl.hidden = false;
+        }
+        if (emptyEl) {
+            emptyEl.hidden = true;
+        }
+    } catch (error) {
+        console.error('Unable to load clinic data', error);
+        if (layoutEl) {
+            layoutEl.hidden = true;
+        }
+        if (emptyEl) {
+            emptyEl.hidden = false;
+        }
+    }
+}
+
+initCabinet();

--- a/clinic/cabinet/index.html
+++ b/clinic/cabinet/index.html
@@ -1,0 +1,74 @@
+<!DOCTYPE html>
+<html lang="ru">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>PetSpot Clinic — Кабинет</title>
+    <link rel="icon" type="image/png" href="../../images/favicon.ico">
+    <link rel="stylesheet" href="../../styles.css">
+    <link rel="stylesheet" href="../clinic.css">
+</head>
+<body class="clinic-page clinic-cabinet-page">
+<section class="hero clinic-hero">
+    <div class="hero-inner">
+        <div class="hero-header">
+            <div class="topbar">
+                <div class="logo-block">
+                    <div class="logo">
+                        <img src="../../images/logo.png" alt="PetSpot logo">
+                    </div>
+                    <span class="logo-text">PetSpot Clinic</span>
+                </div>
+            </div>
+        </div>
+        <div class="hero-body page-stack">
+            <div class="cabinet-layout" id="cabinet-layout" hidden>
+                <aside class="cabinet-sidebar">
+                    <h2 id="clinic-name">Клиника</h2>
+                    <div class="cabinet-info" id="clinic-info"></div>
+                    <button class="clinic-logout-btn" type="button" id="clinic-logout">Выйти</button>
+                </aside>
+                <div class="cabinet-content">
+                    <h1 id="cabinet-title">Личный кабинет клиники</h1>
+                    <p id="cabinet-subtitle">Здесь появятся инструменты для управления профилем и услугами вашей клиники.</p>
+                    <div id="cabinet-extra"></div>
+                </div>
+            </div>
+            <div class="cabinet-empty" id="cabinet-empty" hidden>
+                <p>Не удалось загрузить данные клиники. Попробуйте обновить страницу или войдите снова.</p>
+                <button class="clinic-logout-btn" type="button" id="cabinet-logout-fallback">На страницу входа</button>
+            </div>
+        </div>
+    </div>
+</section>
+<footer class="footer">
+    <div class="footer-inner">
+        <div class="footer-col">
+            <h4>PetSpot</h4>
+            <p>Онлайн-паспорт питомца и сервисы рядом</p>
+        </div>
+        <div class="footer-col">
+            <h4>Документы</h4>
+            <a href="#">Политика конфиденциальности</a>
+            <a href="#">Условия использования</a>
+        </div>
+        <div class="footer-col">
+            <h4>Контакты</h4>
+            <a href="mailto:support@petspot.love">support@petspot.love</a>
+            <a href="#">Telegram</a>
+        </div>
+        <div class="footer-col">
+            <h4>Язык</h4>
+            <div class="lang-dropdown">
+                <button class="lang-btn" type="button">
+                    <img src="../../images/flags/ru.png" alt="RU">
+                    <span>Русский</span>
+                </button>
+            </div>
+        </div>
+    </div>
+    <div class="footer-bottom">© 2025 PetSpot</div>
+</footer>
+<script type="module" src="./cabinet.js"></script>
+</body>
+</html>

--- a/clinic/clinic.css
+++ b/clinic/clinic.css
@@ -1,0 +1,230 @@
+/* Styles specific to clinic pages while preserving the global look */
+
+body.clinic-page {
+    min-height: 100vh;
+    display: flex;
+    flex-direction: column;
+}
+
+.hero.clinic-hero {
+    flex: 1;
+    display: flex;
+    align-items: flex-start;
+    padding: 64px 0 96px;
+}
+
+.clinic-page .hero-inner {
+    width: 100%;
+}
+
+.clinic-topbar {
+    justify-content: flex-start;
+    gap: 20px;
+}
+
+.clinic-login-body {
+    margin-top: 56px;
+    display: flex;
+    flex-direction: column;
+    align-items: flex-start;
+    gap: 0;
+    width: 100%;
+}
+
+.clinic-login-panel {
+    width: 100%;
+    max-width: 420px;
+    background: rgba(255, 255, 255, 0.82);
+    border-radius: 24px;
+    padding: 36px 40px;
+    box-shadow: 0 24px 60px rgba(0, 0, 0, 0.12);
+    backdrop-filter: blur(18px);
+    -webkit-backdrop-filter: blur(18px);
+}
+
+.clinic-login-panel h1 {
+    margin: 0 0 12px;
+    font-size: 32px;
+    color: #1F1F1F;
+}
+
+.clinic-login-panel p.description {
+    margin: 0 0 28px;
+    font-size: 16px;
+    line-height: 1.55;
+    color: rgba(31, 31, 31, 0.7);
+}
+
+.clinic-form {
+    display: flex;
+    flex-direction: column;
+    gap: 20px;
+}
+
+.clinic-form .field {
+    display: flex;
+    flex-direction: column;
+    gap: 8px;
+}
+
+.clinic-form label {
+    font-size: 15px;
+    font-weight: 600;
+    color: #1F1F1F;
+}
+
+.clinic-form input[type="text"],
+.clinic-form input[type="password"] {
+    width: 100%;
+    padding: 14px 16px;
+    border-radius: 14px;
+    border: 1px solid rgba(0, 0, 0, 0.15);
+    background: rgba(255, 255, 255, 0.92);
+    font-size: 16px;
+}
+
+.clinic-form input:focus {
+    border-color: var(--accent-orange);
+    outline: none;
+    box-shadow: 0 0 0 3px rgba(255, 140, 66, 0.25);
+}
+
+.clinic-form button[type="submit"],
+.clinic-logout-btn {
+    margin-top: 10px;
+    padding: 16px;
+    border-radius: 14px;
+    border: none;
+    background: linear-gradient(135deg, #FF8C42, #FF6B6B);
+    color: var(--white);
+    font-size: 17px;
+    font-weight: 600;
+    cursor: pointer;
+    transition: transform 0.15s ease, box-shadow 0.15s ease;
+}
+
+.clinic-form button[type="submit"]:hover,
+.clinic-form button[type="submit"]:focus,
+.clinic-logout-btn:hover,
+.clinic-logout-btn:focus {
+    transform: translateY(-1px);
+    box-shadow: 0 10px 26px rgba(255, 140, 66, 0.4);
+}
+
+.clinic-status {
+    min-height: 24px;
+    font-size: 14px;
+    color: #d35400;
+}
+
+.clinic-status.error {
+    color: #e74c3c;
+}
+
+.clinic-status.success {
+    color: #27ae60;
+}
+
+.cabinet-layout {
+    display: grid;
+    grid-template-columns: minmax(0, 360px) minmax(0, 1fr);
+    gap: 48px;
+    align-items: start;
+}
+
+.cabinet-sidebar {
+    background: rgba(255, 255, 255, 0.55);
+    border-radius: 28px;
+    padding: 32px;
+    box-shadow: 0 18px 40px rgba(0, 0, 0, 0.08);
+    backdrop-filter: blur(16px);
+    -webkit-backdrop-filter: blur(16px);
+}
+
+.cabinet-sidebar h2 {
+    margin-top: 0;
+    margin-bottom: 16px;
+    font-size: 28px;
+}
+
+.cabinet-info {
+    display: grid;
+    gap: 12px;
+}
+
+.cabinet-info-row {
+    display: grid;
+    gap: 6px;
+}
+
+.cabinet-info-label {
+    font-size: 13px;
+    letter-spacing: 0.05em;
+    color: rgba(0, 0, 0, 0.5);
+    text-transform: uppercase;
+}
+
+.cabinet-info-value {
+    font-size: 17px;
+    color: #1F1F1F;
+    word-break: break-word;
+}
+
+.cabinet-content {
+    background: rgba(255, 255, 255, 0.45);
+    border-radius: 28px;
+    padding: 32px;
+    box-shadow: 0 18px 40px rgba(0, 0, 0, 0.08);
+    backdrop-filter: blur(16px);
+    -webkit-backdrop-filter: blur(16px);
+}
+
+.cabinet-content h1 {
+    margin-top: 0;
+    font-size: 36px;
+}
+
+.cabinet-empty {
+    font-size: 18px;
+    color: rgba(0, 0, 0, 0.6);
+}
+
+@media (max-width: 960px) {
+    .cabinet-layout {
+        grid-template-columns: 1fr;
+    }
+
+    .cabinet-sidebar {
+        order: 2;
+    }
+
+    .cabinet-content {
+        order: 1;
+    }
+}
+
+@media (max-width: 820px) {
+    .hero.clinic-hero {
+        padding: 48px 0 72px;
+    }
+
+    .clinic-login-body {
+        align-items: center;
+        margin-top: 40px;
+    }
+
+    .clinic-topbar {
+        justify-content: center;
+    }
+}
+
+@media (max-width: 640px) {
+    .clinic-login-panel {
+        padding: 32px 28px;
+    }
+
+    .cabinet-content,
+    .cabinet-sidebar {
+        padding: 24px;
+    }
+}

--- a/clinic/login/index.html
+++ b/clinic/login/index.html
@@ -1,0 +1,74 @@
+<!DOCTYPE html>
+<html lang="ru">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>PetSpot Clinic — Вход</title>
+    <link rel="icon" type="image/png" href="../../images/favicon.ico">
+    <link rel="stylesheet" href="../../styles.css">
+    <link rel="stylesheet" href="../clinic.css">
+</head>
+<body class="clinic-page clinic-login-page">
+<section class="hero clinic-hero">
+    <div class="hero-inner">
+        <div class="hero-header">
+            <div class="topbar clinic-topbar">
+                <div class="logo-block">
+                    <div class="logo">
+                        <img src="../../images/logo.png" alt="PetSpot logo">
+                    </div>
+                    <span class="logo-text">PetSpot</span>
+                </div>
+            </div>
+        </div>
+        <div class="hero-body clinic-login-body">
+            <div class="clinic-login-panel">
+                <h1>Кабинет клиники</h1>
+                <p class="description">Войдите, чтобы управлять данными вашей ветеринарной клиники.</p>
+                <form class="clinic-form" id="clinic-login-form">
+                    <div class="field">
+                        <label for="username">Логин</label>
+                        <input type="text" id="username" name="username" autocomplete="username" required>
+                    </div>
+                    <div class="field">
+                        <label for="password">Пароль</label>
+                        <input type="password" id="password" name="password" autocomplete="current-password" required>
+                    </div>
+                    <div class="clinic-status" id="clinic-status" role="status" aria-live="polite"></div>
+                    <button type="submit" id="clinic-submit">Войти</button>
+                </form>
+            </div>
+        </div>
+    </div>
+</section>
+<footer class="footer">
+    <div class="footer-inner">
+        <div class="footer-col">
+            <h4>PetSpot</h4>
+            <p>Онлайн-паспорт питомца и сервисы рядом</p>
+        </div>
+        <div class="footer-col">
+            <h4>Документы</h4>
+            <a href="#">Политика конфиденциальности</a>
+            <a href="#">Условия использования</a>
+        </div>
+        <div class="footer-col">
+            <h4>Контакты</h4>
+            <a href="mailto:support@petspot.love">support@petspot.love</a>
+            <a href="#">Telegram</a>
+        </div>
+        <div class="footer-col">
+            <h4>Язык</h4>
+            <div class="lang-dropdown">
+                <button class="lang-btn" type="button">
+                    <img src="../../images/flags/ru.png" alt="RU">
+                    <span>Русский</span>
+                </button>
+            </div>
+        </div>
+    </div>
+    <div class="footer-bottom">© 2025 PetSpot</div>
+</footer>
+<script type="module" src="./login.js"></script>
+</body>
+</html>

--- a/clinic/login/login.js
+++ b/clinic/login/login.js
@@ -1,0 +1,189 @@
+import { db } from "../../firebase-init.js";
+import {
+    collection,
+    doc,
+    getDoc,
+    getDocs,
+    limit,
+    query,
+    where
+} from "https://www.gstatic.com/firebasejs/10.12.2/firebase-firestore.js";
+
+const SESSION_KEY = 'petspotClinicSession';
+const form = document.getElementById('clinic-login-form');
+const statusEl = document.getElementById('clinic-status');
+const submitBtn = document.getElementById('clinic-submit');
+
+function getSavedSession() {
+    try {
+        const raw = localStorage.getItem(SESSION_KEY);
+        if (!raw) return null;
+        return JSON.parse(raw);
+    } catch (error) {
+        console.warn('Unable to read saved clinic session', error);
+        return null;
+    }
+}
+
+function showStatus(message, type = "") {
+    if (!statusEl) return;
+    statusEl.textContent = message;
+    statusEl.classList.remove('error', 'success');
+    if (type) {
+        statusEl.classList.add(type);
+    }
+}
+
+function saveSession(data) {
+    const payload = {
+        loginDocId: data.loginDocId,
+        clinicId: data.clinicId,
+        username: data.username,
+        name: data.name ?? "",
+        createdAt: Date.now()
+    };
+    localStorage.setItem(SESSION_KEY, JSON.stringify(payload));
+}
+
+const LOGIN_FIELDS = ['username', 'login'];
+
+function normaliseInput(value) {
+    return (value ?? '').toString().trim();
+}
+
+async function findLoginDoc(cleanUsername) {
+    if (!cleanUsername) return null;
+
+    const candidates = Array.from(new Set([
+        cleanUsername,
+        cleanUsername.toLowerCase()
+    ]));
+
+    const loginCollection = collection(db, 'clinics_login');
+    let permissionDenied = false;
+
+    for (const field of LOGIN_FIELDS) {
+        for (const candidate of candidates) {
+            try {
+                const snap = await getDocs(query(loginCollection, where(field, '==', candidate), limit(1)));
+                if (!snap.empty) {
+                    return snap.docs[0];
+                }
+            } catch (error) {
+                if (error?.code === 'permission-denied') {
+                    permissionDenied = true;
+                    break;
+                }
+                throw error;
+            }
+        }
+
+        if (permissionDenied) {
+            break;
+        }
+    }
+
+    if (permissionDenied) {
+        for (const candidate of candidates) {
+            try {
+                const docSnap = await getDoc(doc(loginCollection, candidate));
+                if (docSnap.exists()) {
+                    return docSnap;
+                }
+            } catch (error) {
+                if (error?.code === 'permission-denied') {
+                    throw error;
+                }
+                if (error?.code !== 'not-found') {
+                    throw error;
+                }
+            }
+        }
+    }
+
+    return null;
+}
+
+async function verifyCredentials(username, password) {
+    const cleanUsername = normaliseInput(username);
+    const loginDoc = await findLoginDoc(cleanUsername);
+
+    if (!loginDoc) {
+        return null;
+    }
+
+    const data = loginDoc.data();
+    const storedPassword = normaliseInput(data.password ?? data.pass ?? '');
+    const providedPassword = normaliseInput(password);
+
+    if (!storedPassword || storedPassword !== providedPassword) {
+        return null;
+    }
+
+    const clinicId = data.clinicId ?? data.clinic_id ?? data.id ?? loginDoc.id;
+    const name = data.name ?? data.title ?? '';
+    const resolvedUsername = data.username ?? data.login ?? cleanUsername;
+
+    return {
+        loginDocId: loginDoc.id,
+        clinicId,
+        username: resolvedUsername,
+        name
+    };
+}
+
+const existingSession = getSavedSession();
+if (existingSession?.clinicId) {
+    window.location.replace('../cabinet/');
+}
+
+form?.addEventListener('submit', async (event) => {
+    event.preventDefault();
+    if (!form) return;
+
+    const formData = new FormData(form);
+    const username = (formData.get('username') ?? '').toString();
+    const password = (formData.get('password') ?? '').toString();
+
+    if (!username.trim() || !password.trim()) {
+        showStatus('Введите логин и пароль', 'error');
+        return;
+    }
+
+    submitBtn.disabled = true;
+    submitBtn.textContent = 'Входим...';
+    showStatus('Проверяем данные...');
+
+    let success = false;
+
+    try {
+        const session = await verifyCredentials(username, password);
+        if (!session) {
+            showStatus('Неверный логин или пароль', 'error');
+            return;
+        }
+
+        saveSession(session);
+        showStatus('Успешный вход', 'success');
+        success = true;
+        window.location.href = '../cabinet/';
+    } catch (error) {
+        console.error('Clinic login error', error);
+        const message = error?.code === 'permission-denied'
+            ? 'Нет доступа к данным клиники. Обратитесь к администратору.'
+            : 'Не удалось выполнить вход. Попробуйте позже.';
+        showStatus(message, 'error');
+    } finally {
+        if (!success) {
+            submitBtn.disabled = false;
+            submitBtn.textContent = 'Войти';
+        }
+    }
+});
+
+window.addEventListener('pageshow', () => {
+    if (submitBtn) {
+        submitBtn.disabled = false;
+        submitBtn.textContent = 'Войти';
+    }
+});


### PR DESCRIPTION
## Summary
- realign the clinic login header to reuse the rectangular topbar treatment and move the form beneath it
- refresh clinic login styling with a left-aligned panel that matches the site while remaining responsive
- harden Firestore credential lookup by supporting alternate field names and clearer error handling

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68d93bdb895c8331b1bfba8864cf9a2d