### PR TITLE
Fix clinic login layout topbar

### DIFF
--- a/clinic/clinic.css
+++ b/clinic/clinic.css
@@ -9,15 +9,57 @@ body.clinic-page {
 .hero.clinic-hero {
     flex: 1;
     display: flex;
-    align-items: center;
-    padding-top: 80px;
-    padding-bottom: 80px;
+    justify-content: center;
+    padding-top: 64px;
+    padding-bottom: 96px;
+}
+
+.hero.clinic-hero .hero-inner {
+    width: 100%;
+}
+
+.hero.clinic-hero .hero-header {
+    display: flex;
+    justify-content: center;
+}
+
+.hero.clinic-hero .hero-header .topbar {
+    width: 100%;
+    max-width: 960px;
+}
+
+.hero-body.clinic-hero-body {
+    display: flex;
+    justify-content: center;
+    margin-top: 56px;
 }
 
 .clinic-wrapper {
     width: 100%;
     display: flex;
     justify-content: center;
+}
+
+@media (max-width: 720px) {
+    .hero.clinic-hero {
+        padding-top: 48px;
+        padding-bottom: 72px;
+    }
+
+    .hero-body.clinic-hero-body {
+        margin-top: 36px;
+    }
+
+    .hero.clinic-hero .hero-header .topbar {
+        flex-wrap: wrap;
+        gap: 16px;
+    }
+
+    .hero.clinic-hero .hero-header .header-nav {
+        width: 100%;
+        justify-content: center;
+        margin-left: 0;
+    }
 }
 
 .clinic-card {

--- a/clinic/login/index.html
+++ b/clinic/login/index.html
@@ -11,28 +11,47 @@
 <body class="clinic-page clinic-login-page">
 <section class="hero clinic-hero">
     <div class="hero-inner">
-        <div class="clinic-wrapper">
-            <div class="clinic-card">
+        <div class="hero-header">
+            <div class="topbar">
                 <div class="logo-block">
                     <div class="logo">
                         <img src="../../images/logo.png" alt="PetSpot logo">
                     </div>
                     <span class="logo-text">PetSpot</span>
                 </div>
-                <h1>Кабинет клиники</h1>
-                <p class="description">Войдите, чтобы управлять данными вашей ветеринарной клиники.</p>
-                <form class="clinic-form" id="clinic-login-form">
-                    <div class="field">
-                        <label for="username">Логин</label>
-                        <input type="text" id="username" name="username" autocomplete="username" required>
+
+                <nav class="header-nav">
+                    <a href="../../index.html" data-page="home">Home</a>
+                    <a href="../../index.html#services" data-page="services">Services</a>
+                    <a href="./" class="active" data-page="clinics">Clinics</a>
+                </nav>
+            </div>
+        </div>
+
+        <div class="hero-body clinic-hero-body">
+            <div class="clinic-wrapper">
+                <div class="clinic-card">
+                    <div class="logo-block">
+                        <div class="logo">
+                            <img src="../../images/logo.png" alt="PetSpot logo">
+                        </div>
+                        <span class="logo-text">PetSpot</span>
                     </div>
-                    <div class="field">
-                        <label for="password">Пароль</label>
-                        <input type="password" id="password" name="password" autocomplete="current-password" required>
-                    </div>
-                    <div class="clinic-status" id="clinic-status" role="status" aria-live="polite"></div>
-                    <button type="submit" id="clinic-submit">Войти</button>
-                </form>
+                    <h1>Кабинет клиники</h1>
+                    <p class="description">Войдите, чтобы управлять данными вашей ветеринарной клиники.</p>
+                    <form class="clinic-form" id="clinic-login-form">
+                        <div class="field">
+                            <label for="username">Логин</label>
+                            <input type="text" id="username" name="username" autocomplete="username" required>
+                        </div>
+                        <div class="field">
+                            <label for="password">Пароль</label>
+                            <input type="password" id="password" name="password" autocomplete="current-password" required>
+                        </div>
+                        <div class="clinic-status" id="clinic-status" role="status" aria-live="polite"></div>
+                        <button type="submit" id="clinic-submit">Войти</button>
+                    </form>
+                </div>
             </div>
         </div>
     </div>


### PR DESCRIPTION
## Summary
- add the global topbar to the clinic login page with the clinics tab highlighted
- update clinic-specific styles so the header sits at the top and the login card is centered beneath it
- add responsive adjustments to keep the header usable on smaller screens

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68d9571b4e2c8331a83be6b8c13a0883