### PR TITLE
Simplify clinic login layout

### DIFF
--- a/clinic/login/index.html
+++ b/clinic/login/index.html
@@ -19,24 +19,12 @@
                     </div>
                     <span class="logo-text">PetSpot</span>
                 </div>
-
-                <nav class="header-nav">
-                    <a href="../../index.html" data-page="home">Home</a>
-                    <a href="../../index.html#services" data-page="services">Services</a>
-                    <a href="./" class="active" data-page="clinics">Clinics</a>
-                </nav>
             </div>
         </div>
 
         <div class="hero-body clinic-hero-body">
             <div class="clinic-wrapper">
                 <div class="clinic-card">
-                    <div class="logo-block">
-                        <div class="logo">
-                            <img src="../../images/logo.png" alt="PetSpot logo">
-                        </div>
-                        <span class="logo-text">PetSpot</span>
-                    </div>
                     <h1>Кабинет клиники</h1>
                     <p class="description">Войдите, чтобы управлять данными вашей ветеринарной клиники.</p>
                     <form class="clinic-form" id="clinic-login-form">


### PR DESCRIPTION
## Summary
- remove the navigation links from the clinic login topbar so it only shows the logo
- simplify the clinic login card to display only the heading, description, fields, and sign-in button

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68d95c10dfd88331b2d9ed56008821b5