### PR TITLE
Restyle landing top bar

### DIFF
--- a/styles.css
+++ b/styles.css
@@ -1,27 +1,32 @@
 :root {
-    --accent-orange: #FF8C42;
-    --light-background: #eddcd1;
-    --light-surface: #fff4e2;
+    --app-font: "Noto Sans", system-ui, -apple-system, "Segoe UI", "Roboto", "Helvetica Neue", Arial, sans-serif;
+    --accent-orange: #ff8c42;
+    --content-max-width: 1040px;
+    --light-background: #fff3f0;
+    --light-surface: #ffffff;
     --dark-base: #121212;
-    --medium-base: #1F1F1F;
-    --white: #FFFFFF;
+    --medium-base: #1f1f1f;
+    --white: #ffffff;
     --black: #000000;
-    --light-gray: #CCCCCC;
-    --line: #F1E7DB;
+    --light-gray: #cccccc;
+    --line: #f1e7db;
+    --status-green: #4caf50;
+    --status-red: #ff4c4c;
+    --status-yellow: #ffeb3b;
 }
 
 /* Font */
 @font-face {
-    font-family: "MyUI";
+    font-family: "Noto Sans";
     src: url("fonts/NotoSans.ttf") format("truetype");
-    font-weight: 400;
+    font-weight: 400 800;
     font-style: normal;
     font-display: swap;
 }
 
 body {
     margin: 0;
-    font-family: "MyUI", system-ui, -apple-system, "Segoe UI", Roboto, Arial, sans-serif;
+    font-family: var(--app-font);
     background: var(--light-background);
     color: var(--black);
 }
@@ -63,62 +68,106 @@ a:focus {
 
 .topbar {
     width: 100%;
+    max-width: var(--content-max-width);
     display: flex;
     align-items: center;
     justify-content: space-between;
-    padding: 12px 16px;
-    border-radius: 16px;
-    background: rgba(255, 255, 255, .35);
-    border: 1px solid rgba(255, 255, 255, .6);
-    box-shadow: 0 8px 24px rgba(0, 0, 0, .08);
-    backdrop-filter: blur(14px);
-    -webkit-backdrop-filter: blur(14px);
+    gap: 24px;
+    padding: 12px 24px;
+    border-radius: 18px;
+    background: var(--light-surface);
+    box-shadow: 0 12px 24px rgba(0, 0, 0, 0.06);
+    margin: 24px auto 0;
+    color: var(--black);
 }
 
 .logo-block {
     display: flex;
     align-items: center;
     gap: 12px;
+    min-width: 0;
 }
 
 .logo img {
-    height: 50px;
-    width: 50px;
+    height: 48px;
+    width: 48px;
     border-radius: 50%;
     object-fit: cover;
+    box-shadow: 0 0 0 2px rgba(255, 255, 255, 0.6);
 }
 
 .logo-text {
     font-size: 28px;
     font-weight: 700;
-    color: #333;
+    color: var(--accent-orange);
     line-height: 1;
+    white-space: nowrap;
 }
 
 .header-nav {
     display: flex;
-    gap: 20px;
-    margin-left: auto;
+    align-items: center;
+    justify-content: center;
+    gap: 12px;
+    flex: 1;
 }
 
 .header-nav a {
-    font-size: 18px;
-    font-weight: 500;
-    color: #333;
-    padding: 6px 12px;
-    border-radius: 8px;
-    transition: color .2s, background-color .2s;
-    border: none;
-    background: none;
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    padding: 0 20px;
+    min-height: 40px;
+    border-radius: 999px;
+    font-size: 17px;
+    font-weight: 600;
+    color: var(--black);
+    background: transparent;
+    border: 2px solid transparent;
+    transition: background-color 0.2s ease, color 0.2s ease, box-shadow 0.2s ease;
 }
 
 .header-nav a:hover {
-    color: var(--accent-orange);
+    background-color: rgba(255, 140, 66, 0.12);
 }
 
 .header-nav a.active {
     background: var(--accent-orange);
-    color: #fff;
+    color: var(--white);
+    box-shadow: 0 12px 20px rgba(255, 140, 66, 0.35);
+}
+
+@media (max-width: 900px) {
+    .topbar {
+        flex-wrap: wrap;
+        padding: 12px 18px;
+        row-gap: 12px;
+        margin-top: 16px;
+    }
+
+    .logo-text {
+        font-size: 24px;
+    }
+
+    .header-nav {
+        flex-wrap: wrap;
+        gap: 10px;
+    }
+
+    .header-nav a {
+        flex: 1 1 calc(33.33% - 10px);
+        min-width: 120px;
+    }
+}
+
+@media (max-width: 600px) {
+    .header-nav a {
+        flex: 1 1 100%;
+    }
+
+    .topbar {
+        padding: 12px 16px;
+    }
 }
 
 /* ===== Hero ===== */
@@ -1170,7 +1219,7 @@ p {
     user-select: none;
 }
 /* Единый горизонтальный рельс, чтобы всё совпадало с логотипом */
-:root { --rail-x: 16px; }
+:root { --rail-x: 24px; }
 
 /* Тот же отступ у топбара и у контента страниц (list/details) */
 .topbar { padding: 12px var(--rail-x); }


### PR DESCRIPTION
## Summary
- refresh the global color palette and typography variables to match the updated Noto Sans branding
- restyle the landing top bar with a centered navigation pill layout, new spacing, and accent highlights
- add responsive adjustments so the navigation wraps cleanly on smaller screens while preserving the existing links

## Testing
- Not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68fd1161390083318b592c4fcb50d054