### PR TITLE
Darken PetSpot wordmark in header

### DIFF
--- a/styles.css
+++ b/styles.css
@@ -2209,6 +2209,7 @@ body {
 .logo-text {
     font-size: 25px;
     letter-spacing: -0.035em;
+    color: #202124;
 }
 
 .header-nav a.active {


### PR DESCRIPTION
### Motivation
- Improve contrast of the header wordmark so the PetSpot name reads clearly over the hero and better matches the design reference.

### Description
- Updated `styles.css` to set the `.logo-text` color to `#202124` so the wordmark renders dark (modified file: `styles.css`).

### Testing
- Ran automated checks: verified both hero image files exist via a small Python check, served the site with `python3 -m http.server`, confirmed `curl -I` for `/` and `/clinic/login/` returned HTTP 200, ran `node --check script.js` and `git diff --check`, and all checks passed; visual screenshots were not produced because browser automation tooling was not available.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a4650c669548331b6697f1fd3980b83)